### PR TITLE
Clarification of the servertype

### DIFF
--- a/modules/addons/HivelocityPricingTool/classes/Helpers.php
+++ b/modules/addons/HivelocityPricingTool/classes/Helpers.php
@@ -977,7 +977,7 @@ class Helpers {
         
         $pdo = Capsule::connection()->getPdo();
         $pdo->beginTransaction();
-        $query =  "SELECT id FROM tblproducts WHERE configoption1 = ?";
+        $query =  "SELECT id FROM tblproducts WHERE configoption1 = '{$remoteProductId}' AND servertype = 'Hivelocity'";
         $statement = $pdo->prepare($query);
         $statement->execute([$remoteProductId]);
         $row = $statement->fetch();


### PR DESCRIPTION
Here you need to clarify the servertype, because in my case there were other products with configoption1 that matched $remoteProductId. This was breaking the work of the cron.